### PR TITLE
Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.exe
+gener8

--- a/gener8.go
+++ b/gener8.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 )
 
@@ -46,16 +45,6 @@ func (g *gener8) generate() {
 	}
 	replacer := strings.NewReplacer(subs...)
 
-	g.traceOut("generate:Getwd")
-
-	pwd, err := os.Getwd()
-
-	check(err)
-
-	g.traceOut("generate:Construct out path")
-
-	path := filepath.Join(pwd, g.out)
-
 	tmpFile, err := ioutil.TempFile("", "gener8")
 
 	check(err)
@@ -89,12 +78,12 @@ func (g *gener8) generate() {
 		g.traceOut("generate:SkipFormat - tmpFile")
 	}
 
-	if !compareFiles(tmpFile.Name(), path) {
-		g.traceOut("generate:WriteFile: path: %s", path)
+	if !compareFiles(tmpFile.Name(), g.out) {
+		g.traceOut("generate:WriteFile: path: %s", g.out)
 		rawOutData, err := ioutil.ReadFile(tmpFile.Name())
 		check(err)
 
-		err = ioutil.WriteFile(path, rawOutData, 0644) // r.w r.. r..
+		err = ioutil.WriteFile(g.out, rawOutData, 0644) // r.w r.. r..
 		check(err)
 
 		g.traceOut("generate:WriteFile Complete")
@@ -130,15 +119,10 @@ func (g *gener8) setup() {
 
 	g.traceOut("setup:Complete flag.Parse")
 
-	pwd, err := os.Getwd()
+	g.traceOut("setup:ReadFile: %s", g.in)
 
-	check(err)
-
-	path := filepath.Join(pwd, g.in)
-
-	g.traceOut("setup:ReadFile: %s", path)
-
-	g.inData, err = ioutil.ReadFile(path)
+	var err error
+	g.inData, err = ioutil.ReadFile(g.in)
 
 	check(err)
 }

--- a/gener8.go
+++ b/gener8.go
@@ -25,7 +25,6 @@ type gener8 struct {
 
 const (
 	chunkSize = 64000
-	notExists = "no such file or directory"
 )
 
 func (g *gener8) generate() {
@@ -160,7 +159,7 @@ func (g *gener8) traceOut(format string, a ...interface{}) {
 func compareFiles(file1, file2 string) bool {
 	f1, err := os.Open(file1)
 
-	if err != nil && strings.Contains(err.Error(), notExists) {
+	if err != nil && os.IsNotExist(err) {
 		return false
 	}
 
@@ -168,7 +167,7 @@ func compareFiles(file1, file2 string) bool {
 
 	f2, err := os.Open(file2)
 
-	if err != nil && strings.Contains(err.Error(), notExists) {
+	if err != nil && os.IsNotExist(err) {
 		return false
 	}
 

--- a/gener8.go
+++ b/gener8.go
@@ -34,8 +34,12 @@ func (g *gener8) generate() {
 	}
 
 	if g.kws != "" {
+		g.traceOut("generate:Parsing kws...")
+
 		keywords, err := parseKws(g.kws)
 		check(err)
+
+		g.traceOut("generate:Parsing pkg complete")
 
 		for i := len(keywords) - 1; i > -1; i-- {
 			key := fmt.Sprintf("$kw%d", i+1)

--- a/gener8.go
+++ b/gener8.go
@@ -65,10 +65,13 @@ func (g *gener8) generate() {
 
 	g.traceOut("generate:WriteTempFile: path: %s", tmpFile.Name())
 
-	fmt.Fprintf(tmpFile, "// Auto generated from %s by gener8\n\n", g.in)
-	replacer.WriteString(tmpFile, string(g.inData))
-	tmpFile.Close()
+	_, err = fmt.Fprintf(tmpFile, "// Auto generated from %s by gener8\n\n", g.in)
+	check(err)
 
+	_, err = replacer.WriteString(tmpFile, string(g.inData))
+	check(err)
+
+	err = tmpFile.Close()
 	check(err)
 
 	if !g.skipFormat {
@@ -98,22 +101,6 @@ func (g *gener8) generate() {
 		g.traceOut("generate:WriteFile Complete")
 	} else {
 		g.traceOut("generate:WriteFile Skipped...")
-	}
-
-	if !g.skipFormat {
-		g.traceOut("generate:Formatting output file")
-
-		cmd := exec.Command("gofmt", "-w", path)
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-
-		if err != nil {
-			check(fmt.Errorf("gofmt -w %s failed: %s", g.out, err))
-		}
-
-		g.traceOut("generate:Formatting complete")
-	} else {
-		g.traceOut("generate:SkipFormat")
 	}
 }
 

--- a/gener8.go
+++ b/gener8.go
@@ -30,7 +30,9 @@ func (g *gener8) generate() {
 	subs := []string{}
 
 	if g.pkg != "" {
+		g.traceOut("generate:Parsing pkg...")
 		subs = append(subs, "$pkg", g.pkg)
+		g.traceOut("generate:Parsing pkg complete")
 	}
 
 	if g.kws != "" {

--- a/gener8_test.go
+++ b/gener8_test.go
@@ -19,8 +19,8 @@ func TestParsing(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(*keywords) != 3 {
-		t.Error("Found ", len(*keywords), " should be 3")
+	if len(keywords) != 3 {
+		t.Error("Found ", len(keywords), " should be 3")
 	}
 
 	kws = "a,b,\"d,e\""
@@ -31,8 +31,8 @@ func TestParsing(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(*keywords) != 3 {
-		t.Error("Found ", len(*keywords), " should be 3")
+	if len(keywords) != 3 {
+		t.Error("Found ", len(keywords), " should be 3")
 	}
 
 	kws = "AAA,AaA,aaaAAAaaa,"
@@ -43,8 +43,8 @@ func TestParsing(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(*keywords) != 4 {
-		t.Error("Found ", len(*keywords), " should be 3")
+	if len(keywords) != 4 {
+		t.Error("Found ", len(keywords), " should be 3")
 	}
 }
 
@@ -58,9 +58,7 @@ func TestGenerate(t *testing.T) {
 	out := fmt.Sprintf("test_%d.gr8.tmp", time.Now().Unix())
 	testFileOutput := filepath.Join(pwd, out)
 
-	defer func() {
-		os.Remove(testFileOutput)
-	}()
+	defer os.Remove(testFileOutput)
 
 	g := &gener8{
 		skipFormat: true,

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/getkalido/gener8
+
+go 1.15


### PR DESCRIPTION
Instead of doing a call of `regexp.ReplaceAllString` for each kw,
do all the substitutions in one pass, using `strings.Replacer`